### PR TITLE
feat: allow close icon to persist when zoomed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ const [visible, setIsVisible] = useState(false);
 | `doubleTapToZoomEnabled` | Zoom image by double tap on it: default `true`                                                      | boolean                                                     | false    |
 | `HeaderComponent`        | Header component, gets current `imageIndex` as a prop                                               | component, function                                         | false    |
 | `FooterComponent`        | Footer component, gets current `imageIndex` as a prop                                               | component, function                                         | false    |
+| `hideCloseButtonOnZoom`  | Disable hiding the close button on zoom: default `true`                                             | boolean                                                     | false    |
 
 - type ImageSource = ImageURISource | ImageRequireSource
 

--- a/src/ImageViewing.tsx
+++ b/src/ImageViewing.tsx
@@ -41,6 +41,7 @@ type Props = {
   delayLongPress?: number;
   HeaderComponent?: ComponentType<{ imageIndex: number }>;
   FooterComponent?: ComponentType<{ imageIndex: number }>;
+  hideCloseButtonOnZoom?: boolean;
 };
 
 const DEFAULT_ANIMATION_TYPE = "fade";
@@ -48,6 +49,7 @@ const DEFAULT_BG_COLOR = "#000";
 const DEFAULT_DELAY_LONG_PRESS = 800;
 const SCREEN = Dimensions.get("screen");
 const SCREEN_WIDTH = SCREEN.width;
+const DEFAULT_HIDE_CLOSE_BUTTON_ON_ZOOM = true;
 
 function ImageViewing({
   images,
@@ -64,6 +66,7 @@ function ImageViewing({
   delayLongPress = DEFAULT_DELAY_LONG_PRESS,
   HeaderComponent,
   FooterComponent,
+  hideCloseButtonOnZoom = DEFAULT_HIDE_CLOSE_BUTTON_ON_ZOOM,
 }: Props) {
   const imageList = React.createRef<VirtualizedList<ImageSource>>();
   const [opacity, onRequestCloseEnhanced] = useRequestClose(onRequestClose);
@@ -84,9 +87,11 @@ function ImageViewing({
     (isScaled: boolean) => {
       // @ts-ignore
       imageList?.current?.setNativeProps({ scrollEnabled: !isScaled });
-      toggleBarsVisible(!isScaled);
+      if (hideCloseButtonOnZoom) {
+        toggleBarsVisible(!isScaled);
+      }
     },
-    [imageList],
+    [imageList]
   );
 
   if (!visible) {
@@ -106,15 +111,13 @@ function ImageViewing({
       <StatusBarManager presentationStyle={presentationStyle} />
       <View style={[styles.container, { opacity, backgroundColor }]}>
         <Animated.View style={[styles.header, { transform: headerTransform }]}>
-          {typeof HeaderComponent !== "undefined"
-            ? (
-              React.createElement(HeaderComponent, {
-                imageIndex: currentImageIndex,
-              })
-            )
-            : (
-              <ImageDefaultHeader onRequestClose={onRequestCloseEnhanced} />
-            )}
+          {typeof HeaderComponent !== "undefined" ? (
+            React.createElement(HeaderComponent, {
+              imageIndex: currentImageIndex,
+            })
+          ) : (
+            <ImageDefaultHeader onRequestClose={onRequestCloseEnhanced} />
+          )}
         </Animated.View>
         <VirtualizedList
           ref={imageList}


### PR DESCRIPTION
Allows user to disable the close button from hiding when zooming. Default value is `true` which will maintain the same default behavior.