### PR TITLE
Add Loading and Error Component

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ const [visible, setIsVisible] = useState(false);
 | `doubleTapToZoomEnabled` | Zoom image by double tap on it: default `true`                                                      | boolean                                                     | false    |
 | `HeaderComponent`        | Header component, gets current `imageIndex` as a prop                                               | component, function                                         | false    |
 | `FooterComponent`        | Footer component, gets current `imageIndex` as a prop                                               | component, function                                         | false    |
+| `ErrorComponent`        | Error component loaded when image `onError` is called                                             | component, function                                         | false    |
+| `LoadingComponent`        | Loading component shown while image is loading                                            | component, function                                         | false    |
 
 - type ImageSource = ImageURISource | ImageRequireSource
 

--- a/src/ImageViewing.tsx
+++ b/src/ImageViewing.tsx
@@ -42,6 +42,8 @@ type Props = {
   delayLongPress?: number;
   HeaderComponent?: ComponentType<{ imageIndex: number }>;
   FooterComponent?: ComponentType<{ imageIndex: number }>;
+  ErrorComponent?: ComponentType;
+  LoadingComponent?: ComponentType;
 };
 
 const DEFAULT_ANIMATION_TYPE = "fade";
@@ -66,6 +68,8 @@ function ImageViewing({
   delayLongPress = DEFAULT_DELAY_LONG_PRESS,
   HeaderComponent,
   FooterComponent,
+  ErrorComponent,
+  LoadingComponent,
 }: Props) {
   const imageList = React.createRef<VirtualizedList<ImageSource>>();
   const [opacity, onRequestCloseEnhanced] = useRequestClose(onRequestClose);
@@ -145,6 +149,8 @@ function ImageViewing({
               delayLongPress={delayLongPress}
               swipeToCloseEnabled={swipeToCloseEnabled}
               doubleTapToZoomEnabled={doubleTapToZoomEnabled}
+              ErrorComponent={ErrorComponent}
+              LoadingComponent={LoadingComponent}
             />
           )}
           onMomentumScrollEnd={onScroll}

--- a/src/components/ImageItem/ImageErrorWrapper.tsx
+++ b/src/components/ImageItem/ImageErrorWrapper.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { Dimensions, StyleSheet, View } from "react-native";
+
+const SCREEN = Dimensions.get("screen");
+const SCREEN_WIDTH = SCREEN.width;
+const SCREEN_HEIGHT = SCREEN.height;
+
+type Props = {
+  ErrorComponent: React.ComponentType | undefined
+}
+
+export const ImageErrorWrapper: React.FunctionComponent<Props> = ({ ErrorComponent }) => (
+  <View style={styles.container}>
+    {ErrorComponent && React.createElement(ErrorComponent)}
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    width: SCREEN_WIDTH,
+    height: SCREEN_HEIGHT,
+  },
+});

--- a/src/components/ImageItem/ImageItem.d.ts
+++ b/src/components/ImageItem/ImageItem.d.ts
@@ -18,6 +18,8 @@ declare type Props = {
   delayLongPress: number;
   swipeToCloseEnabled?: boolean;
   doubleTapToZoomEnabled?: boolean;
+  ErrorComponent?: ComponentType;
+  LoadingComponent?: ComponentType;
 };
 
 declare const _default: React.MemoExoticComponent<({
@@ -27,6 +29,8 @@ declare const _default: React.MemoExoticComponent<({
   onLongPress,
   delayLongPress,
   swipeToCloseEnabled,
+  ErrorComponent,
+  LoadingComponent,
 }: Props) => JSX.Element>;
 
 export default _default;

--- a/src/components/ImageItem/ImageLoading.tsx
+++ b/src/components/ImageItem/ImageLoading.tsx
@@ -6,7 +6,7 @@
  *
  */
 
-import React from "react";
+import React, { ComponentType } from "react";
 
 import { ActivityIndicator, Dimensions, StyleSheet, View } from "react-native";
 
@@ -14,9 +14,13 @@ const SCREEN = Dimensions.get("screen");
 const SCREEN_WIDTH = SCREEN.width;
 const SCREEN_HEIGHT = SCREEN.height;
 
-export const ImageLoading = () => (
+type Props = {
+  LoadingComponent?: ComponentType;
+}
+
+export const ImageLoading: React.FunctionComponent<Props> = ({ LoadingComponent }) => (
   <View style={styles.loading}>
-    <ActivityIndicator size="small" color="#FFF" />
+    {!LoadingComponent ? <ActivityIndicator size="small" color="#FFF" /> : LoadingComponent}
   </View>
 );
 


### PR DESCRIPTION
Adds the ability to specify a custom `ErrorComponent` that will display when an image fails to load.
Adds the ability to use a custom `LoadingComponent` for the image loader. 

Closes #6 , #117

![Simulator Screen Shot - iPhone 13 Pro - 2022-04-07 at 14 47 22](https://user-images.githubusercontent.com/9149232/162328990-237a0f40-981f-4ca7-92e9-1fc78c26bdaa.png)
 