### PR TITLE
Allow custom close button content

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ const [visible, setIsVisible] = useState(false);
 | `keyExtractor`           | Uniqely identifying each image    | (imageSrc: ImageSource, index: number) => string | false |
 | `imageIndex`             | Current index of image to display                                                                   | number                                                      | true     |
 | `visible`                | Is modal shown or not                                                                               | boolean                                                     | true     |
+| `closeButtonContent` | Custom close button content | ReactNode | false |
 | `onRequestClose`         | Function called to close the modal                                                                  | function                                                    | true     |
 | `onImageIndexChange`     | Function called when image index has been changed                                                   | function                                                    | false    |
 | `onLongPress`            | Function called when image long pressed                                                             | function (event: GestureResponderEvent, image: ImageSource) | false    |

--- a/src/ImageViewing.tsx
+++ b/src/ImageViewing.tsx
@@ -25,12 +25,14 @@ import useAnimatedComponents from "./hooks/useAnimatedComponents";
 import useImageIndexChange from "./hooks/useImageIndexChange";
 import useRequestClose from "./hooks/useRequestClose";
 import { ImageSource } from "./@types";
+import type { ReactNode } from 'react';
 
 type Props = {
   images: ImageSource[];
   keyExtractor?: (imageSrc: ImageSource, index: number) => string;
   imageIndex: number;
   visible: boolean;
+  closeButtonContent?: ReactNode;
   onRequestClose: () => void;
   onLongPress?: (image: ImageSource) => void;
   onImageIndexChange?: (imageIndex: number) => void;
@@ -55,6 +57,7 @@ function ImageViewing({
   keyExtractor,
   imageIndex,
   visible,
+  closeButtonContent,
   onRequestClose,
   onLongPress = () => {},
   onImageIndexChange,
@@ -110,7 +113,10 @@ function ImageViewing({
               imageIndex: currentImageIndex,
             })
           ) : (
-            <ImageDefaultHeader onRequestClose={onRequestCloseEnhanced} />
+            <ImageDefaultHeader
+              closeButtonContent={closeButtonContent}
+              onRequestClose={onRequestCloseEnhanced}
+            />
           )}
         </Animated.View>
         <VirtualizedList

--- a/src/components/ImageDefaultHeader.tsx
+++ b/src/components/ImageDefaultHeader.tsx
@@ -7,22 +7,25 @@
  */
 
 import React from "react";
+import type { ReactNode } from 'react';
+
 import { SafeAreaView, Text, TouchableOpacity, StyleSheet } from "react-native";
 
 type Props = {
+  closeButtonContent?: ReactNode;
   onRequestClose: () => void;
 };
 
 const HIT_SLOP = { top: 16, left: 16, bottom: 16, right: 16 };
 
-const ImageDefaultHeader = ({ onRequestClose }: Props) => (
+const ImageDefaultHeader = ({ closeButtonContent, onRequestClose }: Props) => (
   <SafeAreaView style={styles.root}>
     <TouchableOpacity
-      style={styles.closeButton}
+      style={(closeButtonContent ? {} : styles.closeButton)}
       onPress={onRequestClose}
       hitSlop={HIT_SLOP}
     >
-      <Text style={styles.closeText}>✕</Text>
+      {closeButtonContent ? closeButtonContent : <Text style={styles.closeText}>✕</Text>}
     </TouchableOpacity>
   </SafeAreaView>
 );


### PR DESCRIPTION
Make it possible to customize the close button content:

```jsx
<ImageView
  closeButtonContent={
    <Text
      style={{
        // ...
      }}
    >
      Close
    </Text>
  }
  // ...
/>

```
It preserves the old content if `closeButtonContent` is not provided.