### PR TITLE
Fix #149 Pinch zoom on IOS

### DIFF
--- a/src/ImageViewing.tsx
+++ b/src/ImageViewing.tsx
@@ -31,6 +31,7 @@ type Props = {
   keyExtractor?: (imageSrc: ImageSource, index: number) => string;
   imageIndex: number;
   visible: boolean;
+  maxScale?: number;
   onRequestClose: () => void;
   onLongPress?: (image: ImageSource) => void;
   onImageIndexChange?: (imageIndex: number) => void;
@@ -47,6 +48,7 @@ type Props = {
 const DEFAULT_ANIMATION_TYPE = "fade";
 const DEFAULT_BG_COLOR = "#000";
 const DEFAULT_DELAY_LONG_PRESS = 800;
+const DEFAULT_MAX_SCALE = 3;
 const SCREEN = Dimensions.get("screen");
 const SCREEN_WIDTH = SCREEN.width;
 
@@ -55,6 +57,7 @@ function ImageViewing({
   keyExtractor,
   imageIndex,
   visible,
+  maxScale = DEFAULT_MAX_SCALE,
   onRequestClose,
   onLongPress = () => {},
   onImageIndexChange,
@@ -135,6 +138,7 @@ function ImageViewing({
             <ImageItem
               onZoom={onZoom}
               imageSrc={imageSrc}
+              maxScale={maxScale}
               onRequestClose={onRequestCloseEnhanced}
               onLongPress={onLongPress}
               delayLongPress={delayLongPress}

--- a/src/components/ImageItem/ImageItem.android.tsx
+++ b/src/components/ImageItem/ImageItem.android.tsx
@@ -33,6 +33,7 @@ const SCREEN_HEIGHT = SCREEN.height;
 
 type Props = {
   imageSrc: ImageSource;
+  maxScale: number;
   onRequestClose: () => void;
   onZoom: (isZoomed: boolean) => void;
   onLongPress: (image: ImageSource) => void;
@@ -43,6 +44,7 @@ type Props = {
 
 const ImageItem = ({
   imageSrc,
+  maxScale,
   onZoom,
   onRequestClose,
   onLongPress,
@@ -120,6 +122,7 @@ const ImageItem = ({
     <ScrollView
       ref={imageContainer}
       style={styles.listItem}
+      maximumZoomScale={maxScale}
       pagingEnabled
       nestedScrollEnabled
       showsHorizontalScrollIndicator={false}

--- a/src/components/ImageItem/ImageItem.d.ts
+++ b/src/components/ImageItem/ImageItem.d.ts
@@ -12,6 +12,7 @@ import { ImageSource } from "../../@types";
 
 declare type Props = {
   imageSrc: ImageSource;
+  maxScale: number;
   onRequestClose: () => void;
   onZoom: (isZoomed: boolean) => void;
   onLongPress: (image: ImageSource) => void;
@@ -22,6 +23,7 @@ declare type Props = {
 
 declare const _default: React.MemoExoticComponent<({
   imageSrc,
+  maxScale,
   onZoom,
   onRequestClose,
   onLongPress,

--- a/src/components/ImageItem/ImageItem.ios.tsx
+++ b/src/components/ImageItem/ImageItem.ios.tsx
@@ -35,6 +35,7 @@ const SCREEN_HEIGHT = SCREEN.height;
 
 type Props = {
   imageSrc: ImageSource;
+  maxScale: number;
   onRequestClose: () => void;
   onZoom: (scaled: boolean) => void;
   onLongPress: (image: ImageSource) => void;
@@ -45,6 +46,7 @@ type Props = {
 
 const ImageItem = ({
   imageSrc,
+  maxScale,
   onZoom,
   onRequestClose,
   onLongPress,
@@ -62,7 +64,6 @@ const ImageItem = ({
   const scrollValueY = new Animated.Value(0);
   const scaleValue = new Animated.Value(scale || 1);
   const translateValue = new Animated.ValueXY(translate);
-  const maxScale = scale && scale > 0 ? 3 : 1;
 
   const imageOpacity = scrollValueY.interpolate({
     inputRange: [-SWIPE_CLOSE_OFFSET, 0, SWIPE_CLOSE_OFFSET],

--- a/src/components/ImageItem/ImageItem.ios.tsx
+++ b/src/components/ImageItem/ImageItem.ios.tsx
@@ -62,7 +62,7 @@ const ImageItem = ({
   const scrollValueY = new Animated.Value(0);
   const scaleValue = new Animated.Value(scale || 1);
   const translateValue = new Animated.ValueXY(translate);
-  const maxScale = scale && scale > 0 ? Math.max(1 / scale, 1) : 1;
+  const maxScale = scale && scale > 0 ? 3 : 1;
 
   const imageOpacity = scrollValueY.interpolate({
     inputRange: [-SWIPE_CLOSE_OFFSET, 0, SWIPE_CLOSE_OFFSET],


### PR DESCRIPTION
`scale` from iOS behaves differently between expo and native. When using expo, the `scale` value is between 0 and 1. But when using native, the `scale` value is above 1.

To solve this issue, I proposed to change the `maxScale` value to 3. The value 3 is suggested in #149.  
_from my testing, it actually doesn't matter to use what value as long as it's above 1_