### PR TITLE
fix: image zooms in fully after swiping on android

### DIFF
--- a/src/ImageViewing.tsx
+++ b/src/ImageViewing.tsx
@@ -140,6 +140,7 @@ function ImageViewing({
               delayLongPress={delayLongPress}
               swipeToCloseEnabled={swipeToCloseEnabled}
               doubleTapToZoomEnabled={doubleTapToZoomEnabled}
+              currentImageIndex={currentImageIndex}
             />
           )}
           onMomentumScrollEnd={onScroll}

--- a/src/components/ImageItem/ImageItem.android.tsx
+++ b/src/components/ImageItem/ImageItem.android.tsx
@@ -39,6 +39,7 @@ type Props = {
   delayLongPress: number;
   swipeToCloseEnabled?: boolean;
   doubleTapToZoomEnabled?: boolean;
+  currentImageIndex: number;
 };
 
 const ImageItem = ({
@@ -49,6 +50,7 @@ const ImageItem = ({
   delayLongPress,
   swipeToCloseEnabled = true,
   doubleTapToZoomEnabled = true,
+  currentImageIndex,
 }: Props) => {
   const imageContainer = useRef<ScrollView & NativeMethodsMixin>(null);
   const imageDimensions = useImageDimensions(imageSrc);
@@ -80,6 +82,7 @@ const ImageItem = ({
     doubleTapToZoomEnabled,
     onLongPress: onLongPressHandler,
     delayLongPress,
+    currentImageIndex,
   });
 
   const imagesStyles = getImageStyles(

--- a/src/components/ImageItem/ImageItem.d.ts
+++ b/src/components/ImageItem/ImageItem.d.ts
@@ -18,15 +18,19 @@ declare type Props = {
   delayLongPress: number;
   swipeToCloseEnabled?: boolean;
   doubleTapToZoomEnabled?: boolean;
+  currentImageIndex: number;
 };
 
-declare const _default: React.MemoExoticComponent<({
-  imageSrc,
-  onZoom,
-  onRequestClose,
-  onLongPress,
-  delayLongPress,
-  swipeToCloseEnabled,
-}: Props) => JSX.Element>;
+declare const _default: React.MemoExoticComponent<
+  ({
+    imageSrc,
+    onZoom,
+    onRequestClose,
+    onLongPress,
+    delayLongPress,
+    swipeToCloseEnabled,
+    currentImageIndex,
+  }: Props) => JSX.Element
+>;
 
 export default _default;

--- a/src/hooks/usePanResponder.ts
+++ b/src/hooks/usePanResponder.ts
@@ -40,6 +40,7 @@ type Props = {
   doubleTapToZoomEnabled: boolean;
   onLongPress: () => void;
   delayLongPress: number;
+  currentImageIndex: number;
 };
 
 const usePanResponder = ({
@@ -49,6 +50,7 @@ const usePanResponder = ({
   doubleTapToZoomEnabled,
   onLongPress,
   delayLongPress,
+  currentImageIndex,
 }: Props): Readonly<
   [GestureResponderHandlers, Animated.Value, Animated.ValueXY]
 > => {
@@ -119,6 +121,20 @@ const usePanResponder = ({
 
     return () => scaleValue.removeAllListeners();
   });
+
+  useEffect(() => {
+    onZoom(false);
+
+    // workaround for a bug where scaleValue gets incorrectly set after zooming then swiping.
+    // https://github.com/jobtoday/react-native-image-viewing/issues/158
+    const timeout = setTimeout(() => {
+      scaleValue.setValue(initialScale);
+      currentScale = initialScale;
+      currentTranslate = initialTranslate;
+    }, 100);
+
+    return () => clearTimeout(timeout);
+  }, [currentImageIndex]);
 
   const cancelLongPressHandle = () => {
     longPressHandlerRef && clearTimeout(longPressHandlerRef);


### PR DESCRIPTION
fixes: https://github.com/jobtoday/react-native-image-viewing/issues/158 

to repro: 
1. zoom in to first image
2. zoom out
3. swipe to the next image
4. swipe back to the first image
5. first image starts fully zoomed in even though you zoomed out