### PR TITLE
fix: header and footer don't always hide on zoom

### DIFF
--- a/src/hooks/useAnimatedComponents.ts
+++ b/src/hooks/useAnimatedComponents.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import { useRef } from "react";
 import { Animated } from "react-native";
 
 const INITIAL_POSITION = { x: 0, y: 0 };
@@ -15,22 +16,28 @@ const ANIMATION_CONFIG = {
 };
 
 const useAnimatedComponents = () => {
-  const headerTranslate = new Animated.ValueXY(INITIAL_POSITION);
-  const footerTranslate = new Animated.ValueXY(INITIAL_POSITION);
+  const headerTranslate = useRef(new Animated.ValueXY(INITIAL_POSITION));
+  const footerTranslate = useRef(new Animated.ValueXY(INITIAL_POSITION));
 
   const toggleVisible = (isVisible: boolean) => {
     if (isVisible) {
       Animated.parallel([
-        Animated.timing(headerTranslate.y, { ...ANIMATION_CONFIG, toValue: 0 }),
-        Animated.timing(footerTranslate.y, { ...ANIMATION_CONFIG, toValue: 0 }),
+        Animated.timing(headerTranslate.current.y, {
+          ...ANIMATION_CONFIG,
+          toValue: 0,
+        }),
+        Animated.timing(footerTranslate.current.y, {
+          ...ANIMATION_CONFIG,
+          toValue: 0,
+        }),
       ]).start();
     } else {
       Animated.parallel([
-        Animated.timing(headerTranslate.y, {
+        Animated.timing(headerTranslate.current.y, {
           ...ANIMATION_CONFIG,
           toValue: -300,
         }),
-        Animated.timing(footerTranslate.y, {
+        Animated.timing(footerTranslate.current.y, {
           ...ANIMATION_CONFIG,
           toValue: 300,
         }),
@@ -38,8 +45,8 @@ const useAnimatedComponents = () => {
     }
   };
 
-  const headerTransform = headerTranslate.getTranslateTransform();
-  const footerTransform = footerTranslate.getTranslateTransform();
+  const headerTransform = headerTranslate.current.getTranslateTransform();
+  const footerTransform = footerTranslate.current.getTranslateTransform();
 
   return [headerTransform, footerTransform, toggleVisible] as const;
 };


### PR DESCRIPTION
the header and footer should animate hidden when the user zooms and reappear upon zooming out. but this didn't always work.